### PR TITLE
remove TextField and replace with Button for improved UX

### DIFF
--- a/client/src/components/CreatePost.js
+++ b/client/src/components/CreatePost.js
@@ -1,17 +1,25 @@
-import { TextField } from "@mui/material";
-import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Button } from '@mui/material'
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AiOutlinePlus } from 'react-icons/ai'
 
 const CreatePost = () => {
-  const navigate = useNavigate();
+  const navigate = useNavigate()
   return (
-    <TextField
-      sx={{ flexGrow: 1, maxWidth: 300 }}
-      size="small"
-      label="Create a post..."
-      onClick={() => navigate("/posts/create")}
-    />
-  );
-};
+    <Button
+      variant='outlined'
+      size='medium'
+      onClick={() => navigate('/posts/create')}
+      sx={{
+        gap: '0.5rem',
+        minWidth: '150px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <AiOutlinePlus style={{ flexShrink: 0 }} />
+      <span>Create Post</span>
+    </Button>
+  )
+}
 
-export default CreatePost;
+export default CreatePost


### PR DESCRIPTION
This changes the 'Create A Post' prompt from a TextField to a Button.

When I first went to create a new post on the home page, I expected to be able to type into the TextField to create a post. I was confused when I was re-routed to a different page. I think it might be a little clearer if the TextField was changed to a button for a less confusing UX. Feel free to do what you want with the code/suggestion :)

